### PR TITLE
Build container image in verify pipeline

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -58,3 +58,10 @@ jobs:
           args: build --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build container image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: amd64
+          push: false


### PR DESCRIPTION
In non-scratch images there's additional probability of breaking something on base distro side just like that happend to ca-certificates package recently so to negotiate the issue building container images at PR stage is added.