### PR TITLE
Add additional checks for ICMP ping checker to allow it to fail

### DIFF
--- a/checkers/icmp_ping/icmp_ping.go
+++ b/checkers/icmp_ping/icmp_ping.go
@@ -165,6 +165,14 @@ func (p *icmp_ping) Check(ctx context.Context) error {
 	avgRttSeconds.WithLabelValues(checkName, p.host).Set(stats.AvgRTT.Seconds())
 	stdDevRtt.WithLabelValues(checkName, p.host).Set(stats.StdDevRTT.Seconds())
 
+	if stats.PacketsRecv != stats.PacketsSent {
+		return errors.Errorf("expected %d packets, got %d", stats.PacketsSent, stats.PacketsRecv)
+	}
+
+	if stats.PacketLoss > 0 {
+		return errors.Errorf("expected 0 packet loss, got %f", stats.PacketLoss)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Unfortunately there's no clean way to test it since ICMP check uses external library directly now, sow it doesn't allow any kind of mock and real ICMP pings are kinda fragile in unit testing.

Closes #128 