### PR TITLE
Bind BGP session source to configured local_address

### DIFF
--- a/cmd/anycastd/main.go
+++ b/cmd/anycastd/main.go
@@ -32,6 +32,25 @@ var (
 	buildTimestamp = "undefined"
 )
 
+// newPeer builds a gobgp peer definition. localAddress is set as the
+// transport local address so the BGP session is sourced from the configured
+// address instead of whatever the kernel picks by route lookup.
+func newPeer(peer config.Peer, localAddress string) *apipb.Peer {
+	return &apipb.Peer{
+		Conf: &apipb.PeerConf{
+			NeighborAddress: peer.RemoteAddress,
+			PeerAsn:         peer.RemoteASN,
+		},
+		EbgpMultihop: &apipb.EbgpMultihop{
+			Enabled:     peer.EnableMultihop,
+			MultihopTtl: peer.MultihopTTL,
+		},
+		Transport: &apipb.Transport{
+			LocalAddress: localAddress,
+		},
+	}
+}
+
 type spec struct {
 	ConfigPath string    `envconfig:"CONFIG_PATH" default:"/config.yaml"`
 	LogLevel   log.Level `envconfig:"LOG_LEVEL" default:"WARN"`
@@ -101,16 +120,7 @@ func main() {
 
 	for _, peer := range cfg.Announcer.Peers {
 		err = bgpSrv.AddPeer(context.Background(), &apipb.AddPeerRequest{
-			Peer: &apipb.Peer{
-				Conf: &apipb.PeerConf{
-					NeighborAddress: peer.RemoteAddress,
-					PeerAsn:         peer.RemoteASN,
-				},
-				EbgpMultihop: &apipb.EbgpMultihop{
-					Enabled:     peer.EnableMultihop,
-					MultihopTtl: peer.MultihopTTL,
-				},
-			},
+			Peer: newPeer(peer, cfg.Announcer.LocalAddress),
 		})
 		if err != nil {
 			panic(err)

--- a/cmd/anycastd/main_test.go
+++ b/cmd/anycastd/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/runityru/anycastd/config"
+)
+
+func TestNewPeer(t *testing.T) {
+	r := require.New(t)
+
+	p := newPeer(config.Peer{
+		Name:           "test-peer",
+		RemoteAddress:  "10.0.0.1",
+		RemoteASN:      65000,
+		EnableMultihop: true,
+		MultihopTTL:    2,
+	}, "10.0.0.2")
+
+	r.Equal("10.0.0.1", p.Conf.NeighborAddress)
+	r.Equal(uint32(65000), p.Conf.PeerAsn)
+	r.True(p.EbgpMultihop.Enabled)
+	r.Equal(uint32(2), p.EbgpMultihop.MultihopTtl)
+	r.NotNil(p.Transport)
+	r.Equal("10.0.0.2", p.Transport.LocalAddress)
+}


### PR DESCRIPTION
Previously local_address was only used as the NextHop attribute on announced routes; the BGP session itself never set Transport.LocalAddress, so the kernel picked the source IP by route lookup.