### PR TITLE
chore: remove dead LocalASN from announcer.Config and use netip in v3…

### DIFF
--- a/announcer/announcer.go
+++ b/announcer/announcer.go
@@ -21,14 +21,12 @@ type Config struct {
 	GoBGP    GoBGPServer
 	Prefixes []string
 	NextHop  string
-	LocalASN uint32
 }
 
 type announcer struct {
 	gobgp    GoBGPServer
 	prefixes []string
 	nextHop  string
-	localASN uint32
 }
 
 func New(cfg Config) Announcer {
@@ -36,7 +34,6 @@ func New(cfg Config) Announcer {
 		gobgp:    cfg.GoBGP,
 		prefixes: cfg.Prefixes,
 		nextHop:  cfg.NextHop,
-		localASN: cfg.LocalASN,
 	}
 }
 

--- a/announcer/gobgpv3/adapter.go
+++ b/announcer/gobgpv3/adapter.go
@@ -3,8 +3,7 @@ package gobgpv3
 
 import (
 	"context"
-	"strconv"
-	"strings"
+	"net/netip"
 
 	api "github.com/osrg/gobgp/v3/api"
 	"github.com/osrg/gobgp/v3/pkg/server"
@@ -51,15 +50,14 @@ func (a *adapter) DeletePath(ctx context.Context, prefix string) error {
 
 // newPath builds a GoBGP v3 *api.Path for the given prefix and nextHop.
 func newPath(prefix, nextHop string) (*api.Path, error) {
-	l := strings.SplitN(prefix, "/", 2)
-	prefixLen, err := strconv.ParseUint(l[1], 10, 32)
+	p, err := netip.ParsePrefix(prefix)
 	if err != nil {
 		return nil, err
 	}
 
 	nlri, err := apb.New(&api.IPAddressPrefix{
-		Prefix:    l[0],
-		PrefixLen: uint32(prefixLen),
+		Prefix:    p.Addr().String(),
+		PrefixLen: uint32(p.Bits()),
 	})
 	if err != nil {
 		return nil, err
@@ -74,8 +72,13 @@ func newPath(prefix, nextHop string) (*api.Path, error) {
 
 	attrs := []*apb.Any{a1}
 	if nextHop != "" {
+		nh, err := netip.ParseAddr(nextHop)
+		if err != nil {
+			return nil, err
+		}
+
 		a2, err := apb.New(&api.NextHopAttribute{
-			NextHop: nextHop,
+			NextHop: nh.String(),
 		})
 		if err != nil {
 			return nil, err

--- a/cmd/anycastd/main.go
+++ b/cmd/anycastd/main.go
@@ -156,7 +156,6 @@ func main() {
 			GoBGP:    gobgpv3.NewAdapter(bgpSrv),
 			Prefixes: cfg.Announcer.Routes,
 			NextHop:  cfg.Announcer.LocalAddress,
-			LocalASN: cfg.Announcer.LocalASN,
 		})
 
 		strategy, err := service.GetStrategy(svcCfg.Strategy, svcCfg.StrategyOptions)


### PR DESCRIPTION
… adapter

- LocalASN was stored but never read by any announcer method — it only belongs in StartBgpRequest (main.go) and MetricsRepository
- Replace fragile strings.SplitN/strconv CIDR parsing with netip.ParsePrefix in gobgpv3 adapter (validates input, returns clear errors)