### PR TITLE
fix: replace context.TODO() with signal.NotifyContext for graceful sh…

### DIFF
--- a/cmd/anycastd/main.go
+++ b/cmd/anycastd/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/kelseyhightower/envconfig"
 	apipb "github.com/osrg/gobgp/v3/api"
@@ -58,7 +60,8 @@ type spec struct {
 }
 
 func main() {
-	ctx := context.TODO()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	s := spec{}
 	envconfig.MustProcess("", &s)


### PR DESCRIPTION
…utdown

context.TODO() ignored SIGINT/SIGTERM signals, preventing proper graceful shutdown. When the daemon was killed, BGP routes were not withdrawn, causing traffic loss until BGP hold timer expired (~90s).

Replaced with signal.NotifyContext(SIGINT, SIGTERM) so that errgroup cancellation propagates correctly and deferred bgpSrv.StopBgp executes before process exit.