### PR TITLE
build(deps): bump ozzo-validation to v4.4.1 + fix validation

### DIFF
--- a/checkers/icmp_ping/spec.go
+++ b/checkers/icmp_ping/spec.go
@@ -25,7 +25,7 @@ type spec struct {
 
 func (s spec) Validate() error {
 	return validation.ValidateStruct(&s,
-		validation.Field(&s.Static, validation.Required),
+		validation.Field(&s.Static),
 		validation.Field(&s.Tries, validation.Required),
 		validation.Field(&s.Interval, validation.Required),
 		validation.Field(&s.Timeout, validation.Required),

--- a/config/config.go
+++ b/config/config.go
@@ -109,9 +109,9 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	return validation.ValidateStruct(c,
-		validation.Field(&c.Announcer, validation.Required),
+		validation.Field(&c.Announcer),
 		validation.Field(&c.Services, validation.Required),
-		validation.Field(&c.Metrics, validation.Required),
+		validation.Field(&c.Metrics),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/beevik/ntp v1.5.0
-	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+	github.com/go-ozzo/ozzo-validation/v4 v4.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/osrg/gobgp/v3 v3.37.0
 	github.com/pin/tftp v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beevik/ntp v1.5.0 h1:y+uj/JjNwlY2JahivxYvtmv4ehfi3h74fAuABB9ZSM4=
@@ -25,8 +25,8 @@ github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
-github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead57VkAEY4V+Es=
-github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
+github.com/go-ozzo/ozzo-validation/v4 v4.4.1 h1:AQ3X8zHnXEuNE04pyc1H/nmIlroNjgZ7hcY7Xv/IgH8=
+github.com/go-ozzo/ozzo-validation/v4 v4.4.1/go.mod h1:4ZtPNefSnNq39wjL+2We8y2ysqEX/S4D5mPybufHd7Y=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=


### PR DESCRIPTION
## Что это

Объединяет bump `go-ozzo/ozzo-validation/v4` 4.3.0 → 4.4.1 (как в #164) **и** фикс кода, без которого этот bump падает на `unittests`.

## Проблема

В v4.4.1 `IsEmpty()` теперь считает **любую** zero-value структуру «пустой» (раньше — только `time.Time{}`). Из-за этого `validation.Required` на вложенных структурах, реализующих `Validatable` (`Static`, `Announcer`, `Metrics`), стал срабатывать сразу как `cannot be blank` и перестал спускаться во вложенную структуру, теряя детальные сообщения:

```
// было (4.3.0)
announcer: (local_address: cannot be blank; local_asn: cannot be blank; ...); metrics: (address: cannot be blank; enabled: cannot be blank.); services: cannot be blank.

// стало (4.4.1) — менее информативно
announcer: cannot be blank; metrics: cannot be blank; services: cannot be blank.
```

## Решение

Убираю избыточный `validation.Required` с вложенных структур, реализующих `Validatable`. `validation.ValidateStruct` и так рекурсивно вызывает `Validate()` у таких полей, поэтому детальные сообщения сохраняются:

- `config/config.go` — `Config.Validate()`: убрал `Required` с `c.Announcer` и `c.Metrics`
- `checkers/icmp_ping/spec.go` — `spec.Validate()`: убрал `Required` с `s.Static`

Сообщения об ошибках и поведение валидации не изменились (тесты не трогали). Фикс совместим и с 4.3.0, и с 4.4.1.

## Проверка

- `go test ./...` — зелёные под 4.3.0 и 4.4.1
- `go build ./...` — ок

Этот PR закрывает по сути #164 (там только bump без фикса, поэтому он красный).
